### PR TITLE
Upgrade website-pod module to 5.10.0 and add ALB access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,16 +320,16 @@ For production deployments requiring data persistence across instance replacemen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.21.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.7 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | ~> 2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_admin_password_secret"></a> [admin\_password\_secret](#module\_admin\_password\_secret) | infrahouse/secret/aws | 1.1.1 |
-| <a name="module_pmm_pod"></a> [pmm\_pod](#module\_pmm\_pod) | infrahouse/website-pod/aws | 5.9.0 |
+| <a name="module_pmm_pod"></a> [pmm\_pod](#module\_pmm\_pod) | infrahouse/website-pod/aws | 5.10.0 |
 
 ## Resources
 
@@ -354,6 +354,7 @@ For production deployments requiring data persistence across instance replacemen
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_cidr_block"></a> [admin\_cidr\_block](#input\_admin\_cidr\_block) | CIDR block for admin SSH access | `string` | `null` | no |
+| <a name="input_allowed_cidr"></a> [allowed\_cidr](#input\_allowed\_cidr) | List of CIDR blocks allowed to access the PMM ALB | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Days to retain EFS backups | `number` | `365` | no |
 | <a name="input_backup_schedule"></a> [backup\_schedule](#input\_backup\_schedule) | Cron expression for backup schedule | `string` | `"cron(0 2 * * ? *)"` | no |
 | <a name="input_cloudwatch_log_retention_days"></a> [cloudwatch\_log\_retention\_days](#input\_cloudwatch\_log\_retention\_days) | CloudWatch log retention in days | `number` | `365` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Website Pod Module for PMM Server
 module "pmm_pod" {
   source  = "infrahouse/website-pod/aws"
-  version = "5.9.0"
+  version = "5.10.0"
 
   providers = {
     aws     = aws
@@ -32,6 +32,9 @@ module "pmm_pod" {
 
   # SSH access
   key_pair_name = var.ssh_key_name
+
+  # Security
+  alb_ingress_cidr_blocks = var.allowed_cidr
 
   # User data to run PMM container
   userdata = data.cloudinit_config.pmm.rendered

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,12 @@ variable "admin_cidr_block" {
   default     = null
 }
 
+variable "allowed_cidr" {
+  description = "List of CIDR blocks allowed to access the PMM ALB"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 # Security
 variable "rds_security_group_ids" {
   description = <<-EOF


### PR DESCRIPTION
- Upgrade infrahouse/website-pod/aws module from 5.9.0 to 5.10.0
- Add allowed_cidr variable for ALB ingress CIDR blocks (defaults to 0.0.0.0/0)
- Pass allowed_cidr to module as alb_ingress_cidr_blocks parameter

This enables users to restrict ALB access to specific CIDR ranges for enhanced security.
